### PR TITLE
Verify/Fix Gothic 1 classes

### DIFF
--- a/EngineClasses_G1/oCAiHuman.d
+++ b/EngineClasses_G1/oCAiHuman.d
@@ -119,7 +119,7 @@ class zCAIPlayer {
         zCCollObjectCharacter::zEConfigState m_eCollObjectStateOld  : 4;
     };*/
     
-    var int bitfield[6]; //Zur Bedeutung siehe obenstehende Struktur.
+    var int bitfield[3]; //Zur Bedeutung siehe obenstehende Struktur.
     
     
     //Bluteffekte
@@ -197,7 +197,7 @@ class oCAniCtrl_Human {
         var int _zCAIPlayer_slidePolyNormal[3];        
         var int _zCAIPlayer_checkWaterCollBodyLen;  
         var int _zCAIPlayer_modelHeadNode;          
-        var int _zCAIPlayer_bitfield[6]; 
+        var int _zCAIPlayer_bitfield[3];
         var int _zCAIPlayer_bloodVobList_array; 
         var int _zCAIPlayer_bloodVobList_numAlloc;
         var int _zCAIPlayer_bloodVobList_numInArray; 

--- a/EngineClasses_G1/zCCamera.d
+++ b/EngineClasses_G1/zCCamera.d
@@ -80,21 +80,7 @@ class zCCamera {
     // Screen-Effects
     var int screenFadeEnabled;         //zBOOL            
     var int screenFadeColor;           //zCOLOR          
-    var string screenFadeTexture;      //zSTRING            
-    var int screenFadeTextureAniFPS;   //zREAL            
-    
-    /*
-    enum zTRnd_AlphaBlendFunc   {   zRND_ALPHA_FUNC_MAT_DEFAULT,
-                                zRND_ALPHA_FUNC_NONE,                   
-                                zRND_ALPHA_FUNC_BLEND,              
-                                zRND_ALPHA_FUNC_ADD,                    
-                                zRND_ALPHA_FUNC_SUB,                    
-                                zRND_ALPHA_FUNC_MUL,                    
-                                zRND_ALPHA_FUNC_MUL2,                   
-                                zRND_ALPHA_FUNC_TEST,   
-                                zRND_ALPHA_FUNC_BLEND_TEST
-                            };  */
-    var int screenFadeTextureBlendFunc;     //zTRnd_AlphaBlendFunc
+
     var int cinemaScopeEnabled;             //zBOOL 
     var int cinemaScopeColor;               //zCOLOR
 

--- a/EngineClasses_G1/zCOption.d
+++ b/EngineClasses_G1/zCOption.d
@@ -17,7 +17,7 @@
 //  to access ini files.
 //************************************
 
-const int NUM_ENTRIES = 26;
+const int NUM_ENTRIES = 25;
 
 class zCOption {
     var int _vbtl;


### PR DESCRIPTION
Fix unverified and misaligned classes in Gothic 1. (Verification of zCCamera by [withmorten](https://forum.worldofplayers.de/forum/threads/1299679?p=25981018).)