### PR TITLE
Add missing memory write permission

### DIFF
--- a/Ikarus.d
+++ b/Ikarus.d
@@ -4646,6 +4646,7 @@ func void MEMINT_SendToSpy_Implementation(var int errorType, var string text) {
             /* There is a warning "lost focus",
              * that will be printed constantly, unless
              * I reduce its priority here */
+            MemoryProtectionOverride(/*0x4F55C2*/ 5199298, 1);
             MEM_WriteByte(5199298, 1);
         };
     


### PR DESCRIPTION
The circumvention of the continuous "lost focus" warning for Gothic 1 was lacking the necessary memory protection override. This always caused crashes and never showed the actual info box.