### PR TITLE
Add source (header) files

### DIFF
--- a/Ikarus_G1.src
+++ b/Ikarus_G1.src
@@ -1,0 +1,4 @@
+Ikarus_Const_G1.d
+EngineClasses_G1\*.d
+Ikarus.d
+float.d

--- a/Ikarus_G2.src
+++ b/Ikarus_G2.src
@@ -1,0 +1,4 @@
+Ikarus_Const_G2.d
+EngineClasses_G2\*.d
+Ikarus.d
+float.d

--- a/readme.txt
+++ b/readme.txt
@@ -16,3 +16,6 @@ um mit Floatingpointwerten (bzw. zREAL) zu rechnen. Dies stellt eine
 Empfehlenswerte aber nicht notwendige Ergänzung zu Ikarus dar.
 Die Benutzung ist in der Datei selbst erklärt.
 Die Datei muss nach Ikarus.d geparst werden.
+
+Um Ikarus zu nutzen, braucht lediglich Ikarus_G1.src, bzw. Ikarus_G2.src
+in die Gothic.src eingetragen zu werden.


### PR DESCRIPTION
To simplify integration of Ikarus into the Gothic.src, its files are gathered into its own Ikarus_G1.src/Ikarus_G2.src. Having separate SRC files for Gothic 1 and Gothic 2 does not require deleting any files and should thus be more straight forward (as compared to how it is in LeGo at the moment).