### PR TITLE
Prevent possible crash with cached functions

### DIFF
--- a/Ikarus.d
+++ b/Ikarus.d
@@ -2891,7 +2891,7 @@ func void MEM_CallByString (var string fnc) {
     /* Mikrooptimierung: Wird zweimal hintereinander die selbe Funktion
      * mit CallByString aufgerufen, nicht nochmal neu suchen. */
     var int symbID;
-    var string cacheFunc; var int cacheSymbID;
+    const string cacheFunc = ""; const int cacheSymbID = 0;
 
     if (Hlp_StrCmp (cacheFunc, fnc)) {
         symbID = cacheSymbID;


### PR DESCRIPTION
`MEM_CallByString` conveniently caches the last function name and its
symbol. In rare cases this has led to a crash when a previous function
ID was stored in the game save, but became invalid when the code base changed
(i.e. changes in the scripts for new mod version).