### PR TITLE
Fix func by offset

### DIFF
--- a/Ikarus.d
+++ b/Ikarus.d
@@ -2966,6 +2966,11 @@ func int MEM_GetFuncIDByOffset(var int offset) {
         MEM_Error("MEM_GetFuncIDByOffset: Offset is not in valid bounds (0 <= offset < ParserStackSize).");
         return -1;
     };
+
+    /* Handle overwritten functions correctly that immediately jump "nto another function, e.g. MEM_ReadInt */
+    if (MEM_ReadByte(offset + currParserStackAddress) == zPAR_TOK_JUMP) {
+        offset = MEM_ReadInt(offset + currParserStackAddress + 1);
+    };
     
     var zCArray array; array = _^(funcStartsArray);
     

--- a/Ikarus.d
+++ b/Ikarus.d
@@ -2967,7 +2967,7 @@ func int MEM_GetFuncIDByOffset(var int offset) {
         return -1;
     };
 
-    /* Handle overwritten functions correctly that immediately jump "nto another function, e.g. MEM_ReadInt */
+    /* Handle overwritten functions correctly that immediately jump into another function, e.g. MEM_ReadInt */
     if (MEM_ReadByte(offset + currParserStackAddress) == zPAR_TOK_JUMP) {
         offset = MEM_ReadInt(offset + currParserStackAddress + 1);
     };


### PR DESCRIPTION
`MEM_GetFuncIDOffset` failed to find the correct symbol ID for functions
that had been previously overwritten with `MEM_ReplaceFunc`. Most
prominantly this led to a crash when using such a function within a
while condition, i.e. `while(MEM_ReadInt(ptr+i));`
`MEM_GetFuncIDByOffset` now recognizes overwritten functions.