### PR TITLE
Remove warning when initializing without camera

### DIFF
--- a/Ikarus.d
+++ b/Ikarus.d
@@ -3749,7 +3749,11 @@ func void MEM_InitGlobalInst() {
     MEM_Waynet = _^(MEM_World.wayNet);
 
     //Camera
-    MEM_Camera = _^(MEM_Game._zCSession_camera);
+    if (MEM_Game._zCSession_camera) {
+        MEM_Camera = _^(MEM_Game._zCSession_camera);
+    } else {
+        MEM_AssignInstNull (MEM_Camera);
+    };
 
     //SkyController:
     if (MEM_World.skyControlerOutdoor) {


### PR DESCRIPTION
When initializing Ikarus before the game camera was created, e.g. from
`init_perceptions`, a warning occurs. To prevent it, an analogous
if-condition to that of the initialization of the sky controller is used.