### PR TITLE
Follow suitable jumps recursively

### DIFF
--- a/Ikarus.d
+++ b/Ikarus.d
@@ -2969,7 +2969,11 @@ func int MEM_GetFuncIDByOffset(var int offset) {
 
     /* Handle overwritten functions correctly that immediately jump into another function, e.g. MEM_ReadInt */
     if (MEM_ReadByte(offset + currParserStackAddress) == zPAR_TOK_JUMP) {
-        offset = MEM_ReadInt(offset + currParserStackAddress + 1);
+        var int target; target = MEM_ReadInt(offset + currParserStackAddress + 1);
+        // Only for targets within the code stack!
+        if (target >= 0) && (target < MEM_Parser.stack_stacksize) {
+            return MEM_GetFuncIDByOffset(target);
+        };
     };
     
     var zCArray array; array = _^(funcStartsArray);


### PR DESCRIPTION
> For the unlikely (but possible) event that a replaced function is jumping into a function that is later replaced as well, a recursive solution would have been better.

_Ref https://github.com/Lehona/Ikarus/pull/8#issuecomment-470831279_


> Exceptions are things like the `repeat` statement that jump completely out of the code stack. But this is simple to check (i.e. don't follow any jumps that lie beyond the stack; they will not correspond to a valid function symbol anyway).
>
> I hope I'm not making wrong assumptions.

_Ref https://github.com/Lehona/Ikarus/pull/8#issuecomment-470950417_



I haven't run too many tests yet. Let's discuss and, if necessary, change the code before merging.