### PR TITLE
Detect end of code stack while tokenizing function

### DIFF
--- a/Ikarus.d
+++ b/Ikarus.d
@@ -3181,19 +3181,14 @@ func void MEMINT_TokenizeFunction(var int funcID, var int tokenArray, var int pa
     MEM_ArrayInsert(paramArray, param);
     
     if (tok == zPAR_TOK_RET) {
-        if (MEM_GetFuncIDByOffset(pos - currParserStackAddress) != funcID) {
+        if (MEM_GetFuncIDByOffset(pos - currParserStackAddress) != funcID)
+        || (pos >= MEM_Parser.stack_stacklast) {
             /* mark end of function */
             MEM_ArrayInsert(posArr, pos);
             MEM_ArrayInsert(tokenArray, -1);
             MEM_ArrayInsert(paramArray, -1);
             return;
         };
-    } else if (pos - currParserStackAddress >= MEM_Parser.stack_stacksize) {
-        /* special case for very last function in stack, not ideal (will take quite a while) but better than a crash */
-        MEM_ArrayInsert(posArr, pos);
-        MEM_ArrayInsert(tokenArray, -1);
-        MEM_ArrayInsert(paramArray, -1);
-        return;
     };
     
     MEM_StackPos.position = loop;

--- a/Ikarus.d
+++ b/Ikarus.d
@@ -3188,6 +3188,12 @@ func void MEMINT_TokenizeFunction(var int funcID, var int tokenArray, var int pa
             MEM_ArrayInsert(paramArray, -1);
             return;
         };
+    } else if (pos - currParserStackAddress >= MEM_Parser.stack_stacksize) {
+        /* special case for very last function in stack, not ideal (will take quite a while) but better than a crash */
+        MEM_ArrayInsert(posArr, pos);
+        MEM_ArrayInsert(tokenArray, -1);
+        MEM_ArrayInsert(paramArray, -1);
+        return;
     };
     
     MEM_StackPos.position = loop;


### PR DESCRIPTION
The function `MEMINT_TokenizeFunction` had a problem with processing the
very last function in the code stack, because it could not detect its
end. This usually resulted in a crash when using jumps (repeat, etc.),
because `MEMINT_TokenizeFunction` would run "indefinitely".

Detecting the end of the last function is not trivial, because the code
stack is typically larger then necessary (padded with zero, which is a
valid parser token, i.e. `zPAR_OP_PLUS`). The solution offered here only
prevents the crash but results in long waiting time. So it's not optimal
and I'd welcome any suggestions.