### PR TITLE
Return value instead of variable in G1/G2 switch

### DIFF
--- a/Ikarus.d
+++ b/Ikarus.d
@@ -319,9 +319,9 @@ func void MEMINT_GetMemHelper() {
 //GOTHIC_BASE_VERSION == 1 ? g1Val : g2Val
 func int MEMINT_SwitchG1G2(var int g1Val, var int g2Val) {
     if (GOTHIC_BASE_VERSION == 1) {
-        return g1Val;
+        return +g1Val;
     } else {
-        return g2Val;
+        return +g2Val;
     };
 };
 


### PR DESCRIPTION
The function `MEMINT_SwitchG1G2` returns a variable instead of its value. This causes problems with the following usage:
```D
myfunc(MEMINT_SwitchG1G2(a, b), MEMINT_SwitchG1G2(c, d));
```
So far this would require
```D
myfunc(+MEMINT_SwitchG1G2(a, b), +MEMINT_SwitchG1G2(c, d));
```

This PR adds the + within the function (as is done with many other functions already).